### PR TITLE
Update tsconfig.json to fix dist/package.json refs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,12 @@
       "node_modules/@types"
     ]
   },
+  "include": [
+    "src"
+  ],
   "exclude": [
     "dist",
-    "node_modules"
+    "node_modules",
+    "tests"
   ]
 }


### PR DESCRIPTION
## Description of the change

Trying to use this package I discovered that no code could be imported or used since the `dist/` folder was including tests and src, and `package.json` was referring to the main and typings files in `./dist/index.js` and `./dist/index.d.ts` that did not exist, however, they did exist in `./dist/src/index.js` and `./dist/src/index.d.ts`.

I'm assuming including things like `tests/`, `jest.config.js`, `jest.config.d.ts`, `jest.config.js.map` within `dist/` is unintentional. This change removes all of those files from `dist/`, and brings up everything that was in `src/` back up to the root level so that `index.js` and `index.d.ts` are referred to properly in `package.json`.

Alternate solution would be to modify `package.json` to include references to `src`, but I leave that decision up to you.

Testing performed: `npm run build` and manual inspection of `dist/`, as well as manual modification of `dist/` in other project that this was installed in (code discoverable).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
