### PR TITLE
Allow pass through of projectId to get request query param for ticketsMetaPostRetrieve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@mergeapi/merge-sdk-typescript",
-  "version": "2.0.0",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mergeapi/merge-sdk-typescript",
-      "version": "2.0.0",
+      "version": "2.0.4",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "ts-node": "^10.9.1"
       },

--- a/src/ticketing/apis/TicketsApi.ts
+++ b/src/ticketing/apis/TicketsApi.ts
@@ -84,6 +84,10 @@ export interface TicketsMetaPatchRetrieveRequest {
     id: string;
 }
 
+export interface TicketsMetaPostRetrieveRequest {
+    projectId?: string, 
+}
+
 export interface TicketsPartialUpdateRequest {
     id: string;
     patchedTicketEndpointRequest: PatchedTicketEndpointRequest;
@@ -381,8 +385,8 @@ export class TicketsApi extends runtime.BaseAPI {
     /**
      * Returns metadata for `Ticket` POSTs.
      */
-    async ticketsMetaPostRetrieveRaw(): Promise<runtime.ApiResponse<MetaResponse | undefined>> {
-        const queryParameters: any = {};
+    async ticketsMetaPostRetrieveRaw(requestParameters?: TicketsMetaPostRetrieveRequest): Promise<runtime.ApiResponse<MetaResponse | undefined>> {
+        const queryParameters: any = requestParameters || {};
 
         const headerParameters: runtime.HTTPHeaders = {};
 
@@ -408,8 +412,8 @@ export class TicketsApi extends runtime.BaseAPI {
     /**
      * Returns metadata for `Ticket` POSTs.
      */
-    async ticketsMetaPostRetrieve(): Promise<MetaResponse | undefined> {
-        const response = await this.ticketsMetaPostRetrieveRaw();
+    async ticketsMetaPostRetrieve(requestParameters?: TicketsMetaPostRetrieveRequest): Promise<MetaResponse | undefined> {
+        const response = await this.ticketsMetaPostRetrieveRaw(requestParameters);
         return await response.value();
     }
 


### PR DESCRIPTION
## Description of the change

SDK doesn't allow users to set `projectId` for the `ticketsMetaPostRetrieve` request. This is needed to retrieve things like `ticket_type` from Jira (reference doc: https://help.merge.dev/en/articles/6578026-using-meta-for-post-tickets)

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [X] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
