### PR TITLE
add instructions and test for overriding fetchApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ your requests. The `apiKey` property is the API Key of your Merge account, which
 `X-Account-Token` header which identifies which of your customers' data you are requesting. See the following
 examples for calling various category API's:
 
-#### Node-Fetch override on Node version < 17.5
+#### node-fetch override on Node version < 17.5
 
 This SDK relies on the Fetch API, which is baked into Node starting at version 17.5. For those customers on older
 versions of Node, we allow you to explicitly set the fetchApi property like so:
@@ -49,8 +49,8 @@ let test_conf_crm = new Configuration({
 ```
 
 You can find the node-fetch package here: https://www.npmjs.com/package/node-fetch . We have tested that
-node-fetch @ 2.x.x can be passed in directly on node version 16.0.0, however later versions of node-fetch or later
-versions of node may require additional type adjustments to make it work.
+node-fetch @ 2.x.x can be passed in directly on Node version 16.0.0, however later versions of node-fetch or later
+versions of Node may require additional type adjustments to make it work.
 
 #### Accounting
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ your requests. The `apiKey` property is the API Key of your Merge account, which
 `X-Account-Token` header which identifies which of your customers' data you are requesting. See the following
 examples for calling various category API's:
 
+#### Node-Fetch override on Node version < 17.5
+
+This SDK relies on the Fetch API, which is baked into Node starting at version 17.5. For those customers on older
+versions of Node, we allow you to explicitly set the fetchApi property like so:
+
+```
+import fetch from 'node-fetch'
+
+...
+
+let test_conf_crm = new Configuration({
+    apiKey: "REDACTED",
+    accessToken: "REDACTED",
+    fetchApi: fetch
+});
+```
+
+You can find the node-fetch package here: https://www.npmjs.com/package/node-fetch . We have tested that
+node-fetch @ 2.x.x can be passed in directly on node version 16.0.0, however later versions of node-fetch or later
+versions of node may require additional type adjustments to make it work.
+
 #### Accounting
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@mergeapi/merge-sdk-typescript",
-  "version": "2.0.0",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mergeapi/merge-sdk-typescript",
-      "version": "2.0.0",
+      "version": "2.0.4",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "ts-node": "^10.9.1"
       },
@@ -14,6 +15,7 @@
         "@types/jest": "^28.1.6",
         "@types/node": "^15.12.2",
         "jest": "^28.1.3",
+        "node-fetch": "2.0.0",
         "ts-jest": "^28.0.7",
         "typescript": "^4.3.3"
       }
@@ -2781,6 +2783,15 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.0.0.tgz",
+      "integrity": "sha512-bici2HCWFnAghTYMcy12WPxrEwJ5qK7GQJOTwTfyEZjyL99ECWxbYQfabZ2U1zrHMKkOBE97Z9iHIuKQfCMdzQ==",
+      "dev": true,
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -5787,6 +5798,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.0.0.tgz",
+      "integrity": "sha512-bici2HCWFnAghTYMcy12WPxrEwJ5qK7GQJOTwTfyEZjyL99ECWxbYQfabZ2U1zrHMKkOBE97Z9iHIuKQfCMdzQ==",
       "dev": true
     },
     "node-int64": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/jest": "^28.1.6",
     "@types/node": "^15.12.2",
     "jest": "^28.1.3",
+    "node-fetch": "2.0.0",
     "ts-jest": "^28.0.7",
     "typescript": "^4.3.3"
   },

--- a/tests/simple.test.ts
+++ b/tests/simple.test.ts
@@ -1,5 +1,6 @@
 import * as merge_sdk from '../src/index'
 import { Configuration } from '../src/index';
+import fetch from 'node-fetch'
 
 // note this is skipped for CI, just here for reference
 test.skip("can call account details api", async () => {
@@ -83,3 +84,24 @@ test.skip("can call account details api", async () => {
     expect(response6).toBeDefined()
     expect(response6?.previous).toBeDefined()
 });
+
+test.skip("can override fetchApi in the configuration", async () => {
+    /*
+    REDACTED TEST CONFS
+    */
+
+    let test_conf_crm = new Configuration({
+        apiKey: "REDACTED",
+        accessToken: "REDACTED",
+        fetchApi: fetch
+    });
+
+    // crm call
+    let contacts_api = new merge_sdk.CRM.ContactsApi(test_conf_crm)
+
+    let response = await contacts_api.contactsList({
+    })
+
+    console.log(response)
+    expect(response).toBeDefined()
+})


### PR DESCRIPTION
## Description of the change

Adds instructions for using the `fetchApi` property of the `Configuration` object necessary to run on older versions of node.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
