### PR TITLE
add v 3.0.2 with response.clone() fix for node-fetch memory issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 3.0.2
+
+# Date: 2022-01-31
+
+- Updated response.clone() fix from version 3.0.0 to not run response.clone() AT ALL unless a middleware exists that needs it (previously always doing clone once and only once)
+
 # Version 3.0.1
 
 # Date: 2022-01-20

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## @mergeapi/merge-sdk-typescript@3.0.1
+## @mergeapi/merge-sdk-typescript@3.0.2
 
 This is the Merge API, Inc. SDK client for Typescript. It utilizes [Fetch API](https://fetch.spec.whatwg.org/) to
 make requests to Merge on behalf of customers. We recommend only using this module in NodeJS server environments.
@@ -171,7 +171,7 @@ navigate to the folder of your consuming project and run one of the following co
 _published:_
 
 ```
-npm install @mergeapi/merge-sdk-typescript@3.0.1 --save
+npm install @mergeapi/merge-sdk-typescript@3.0.2 --save
 ```
 
 _unPublished (not recommended):_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/merge-sdk-typescript",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "NodeJS client for Merge API, Inc's unified API's.",
   "author": "hello@merge.dev",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Description of the change

Turns out, even cloning once can run afoul of the memory issues given a moderately large response payload... so avoid it altogether whenever possible.

Added warning comment and documented to changelog for posterity

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
