### PR TITLE
fix array query params, add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 3.0.5
+
+# Date: 2022-02-14
+
+- The base APIClient was failing to serialize array-type query params in a way our server understood. This is now fixed.
+
 # Version 3.0.4
 
 # Date: 2022-02-10

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ navigate to the folder of your consuming project and run one of the following co
 _published:_
 
 ```
-npm install @mergeapi/merge-sdk-typescript@3.0.4 --save
+npm install @mergeapi/merge-sdk-typescript@3.0.5 --save
 ```
 
 _unPublished (not recommended):_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/merge-sdk-typescript",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "NodeJS client for Merge API, Inc's unified API's.",
   "author": "hello@merge.dev",
   "main": "./dist/index.js",

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -239,7 +239,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
             const value = params[key];
             if (value instanceof Array) {
                 const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-                    .join(`&${encodeURIComponent(fullKey)}=`);
+                    .join(',');
                 return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
             if (value instanceof Date) {

--- a/tests/simple.test.ts
+++ b/tests/simple.test.ts
@@ -1,5 +1,5 @@
 import * as merge_sdk from '../src/index'
-import { Configuration, JSONValue } from '../src/index';
+import { Configuration, JSONValue, querystring } from '../src/index';
 import fetch from 'node-fetch'
 
 // note this is skipped for CI, just here for reference
@@ -124,4 +124,13 @@ test("can deserialize known enum values", async () => {
     expect(employment_deserialized?.employment_type).toBeDefined()
     expect(employment_deserialized?.employment_type?.value).toEqual(merge_sdk.HRIS.EmploymentTypeEnumValues.FullTime)
     expect(employment_deserialized?.employment_type?.rawValue).toEqual(merge_sdk.HRIS.EmploymentTypeEnumValues.FullTime)
+})
+
+test("query params use comma-separated-value format", async() => {
+    let serialized_query_params = querystring({
+        "expand": ["a", "b", "c"],
+        "single": 1
+    });
+
+    expect(serialized_query_params).toEqual("expand=a,b,c&single=1");
 })


### PR DESCRIPTION
## Description of the change

Unfortunately, the prior implementation of array-based query params in this SDK used this style:

`param=1&param=2&param=3`

to serialize array values. This was not recognized by Merge's API server, so we move to a comma separated style:

`param=1,2,3`

which will work.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
